### PR TITLE
fix: read MangaPlus API responses as protobuf

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": 1785078000,
-  "date": "Sun Jul 26 15:00:00 +0000 2026",
-  "chapter": 1189
+  "timestamp": 1786287600,
+  "date": "Sun Aug 09 15:00:00 +0000 2026",
+  "chapter": 1190
 }

--- a/update_schedule.py
+++ b/update_schedule.py
@@ -14,21 +14,88 @@ TITLE_ID = 100020  # One Piece
 SECRET_SALT = '4Kin9vGg'
 HEADERS = {'User-Agent': 'okhttp/4.12.0', 'Accept-Encoding': 'gzip'}
 
+# Field numbers from the app's protobuf schema. Responses used to be readable
+# with `format=json`, but that query parameter is now rejected at the edge with
+# a bare nginx 403, so we speak the app's native protobuf instead.
+RESPONSE_SUCCESS = 1
+RESPONSE_ERROR = 2
+ERROR_ENGLISH_POPUP = 2
+POPUP_SUBJECT = 1
+POPUP_BODY = 2
+SUCCESS_REGISTRATION = 2
+REGISTRATION_DEVICE_SECRET = 1
+SUCCESS_TITLE_DETAIL = 8
+DETAIL_NEXT_TIMESTAMP = 5
+DETAIL_CHAPTER = 38
+CHAPTER_NAME = 3
 
-def _base(params):
-    return {**params, 'os': 'android', 'os_ver': 35, 'app_ver': APP_VERSION, 'format': 'json'}
+
+def _varint(buf, pos):
+    result = shift = 0
+    while True:
+        byte = buf[pos]
+        pos += 1
+        result |= (byte & 0x7F) << shift
+        if not byte & 0x80:
+            return result, pos
+        shift += 7
+
+
+def _fields(buf):
+    """Yield (field_number, value) pairs of a protobuf message.
+
+    Values are ints for varints and bytes for length-delimited fields; fixed
+    width fields are skipped since nothing we read uses them.
+    """
+    pos = 0
+    while pos < len(buf):
+        key, pos = _varint(buf, pos)
+        field, wire = key >> 3, key & 7
+        if wire == 0:
+            value, pos = _varint(buf, pos)
+        elif wire == 1:
+            value, pos = None, pos + 8
+        elif wire == 2:
+            length, pos = _varint(buf, pos)
+            value, pos = buf[pos:pos + length], pos + length
+        elif wire == 5:
+            value, pos = None, pos + 4
+        else:
+            raise ValueError(f'unsupported protobuf wire type {wire}')
+        yield field, value
+
+
+def _get(buf, field):
+    for number, value in _fields(buf):
+        if number == field:
+            return value
+    return None
+
+
+def _get_all(buf, field):
+    return [value for number, value in _fields(buf) if number == field]
+
+
+def _text(value):
+    return value.decode('utf-8') if value is not None else None
 
 
 def _call(method, path, secret=None, **params):
     if secret:
         params['secret'] = secret
-    res = requests.request(method, f'{API}/{path}', params=_base(params), headers=HEADERS, timeout=30)
+    params = {**params, 'os': 'android', 'os_ver': 35, 'app_ver': APP_VERSION}
+    res = requests.request(method, f'{API}/{path}', params=params, headers=HEADERS, timeout=30)
     res.raise_for_status()
-    data = res.json()
-    if 'error' in data:
-        popup = data['error'].get('englishPopup', {})
-        raise RuntimeError(f"{popup.get('subject')}: {popup.get('body')}")
-    return data['success']
+
+    error = _get(res.content, RESPONSE_ERROR)
+    if error is not None:
+        popup = _get(error, ERROR_ENGLISH_POPUP) or b''
+        raise RuntimeError(f'{_text(_get(popup, POPUP_SUBJECT))}: {_text(_get(popup, POPUP_BODY))}')
+
+    success = _get(res.content, RESPONSE_SUCCESS)
+    if success is None:
+        raise RuntimeError(f'Unexpected response from {path}: {res.content[:200]!r}')
+    return success
 
 
 def register():
@@ -37,22 +104,22 @@ def register():
     device_token = hashlib.md5(str(uuid.uuid4()).encode()).hexdigest()
     security_key = hashlib.md5((device_token + SECRET_SALT).encode()).hexdigest()
     data = _call('PUT', 'register', device_token=device_token, security_key=security_key)
-    return data['registerationData']['deviceSecret']
+    return _text(_get(_get(data, SUCCESS_REGISTRATION), REGISTRATION_DEVICE_SECRET))
 
 
 if __name__ == '__main__':
     secret = register()
     detail = _call('GET', 'title_detailV3', secret=secret, title_id=TITLE_ID, lang='eng', clang='eng')
-    view = detail['titleDetailView']
+    view = _get(detail, SUCCESS_TITLE_DETAIL)
 
-    timestamp = view.get('nextTimeStamp')
+    timestamp = _get(view, DETAIL_NEXT_TIMESTAMP) if view is not None else None
     if not timestamp:
         print('No nextTimeStamp found in the response.')
     else:
         try:
-            last_chapter = view['chapterListV2'][-1]['name']
+            last_chapter = _text(_get(_get_all(view, DETAIL_CHAPTER)[-1], CHAPTER_NAME))
             current_chapter = int(last_chapter.replace('#', '')) + 1
-        except (IndexError, KeyError, ValueError):
+        except (AttributeError, IndexError, ValueError):
             current_chapter = ''
 
         date_str = datetime.datetime.fromtimestamp(timestamp, datetime.UTC)


### PR DESCRIPTION
## Problem

The scheduled `Update schedule` workflow fails at the `python update_schedule.py` step:

```
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url:
https://jumpg-api.tokyo-cdn.com/api/register?...&format=json
```

The 403 is a bare nginx error page, not an API-level error. Probing the host shows the block is triggered by the `format=json` query parameter specifically — every other combination of endpoint, `app_ver`, and headers returns 200, and the same request with the parameter removed succeeds. SHUEISHA appears to have disabled the JSON rendering of the API at the edge; the device-register handshake and the endpoints themselves still work.

## Fix

Stop asking for JSON and read the app's native protobuf responses instead:

- Drop `format` from the request parameters (protobuf is the default).
- Add a ~40-line protobuf reader that walks the wire format and pulls only the fields this script needs: the device secret from `register`, and `nextTimeStamp` plus the last chapter's `name` from `title_detailV3`.
- Field numbers are named as constants at the top of the file.

Error responses are still surfaced with the English popup subject/body, same as before.

## Verification

Ran the script locally against the live API:

```
Updating schedule with: {'timestamp': 1786287600, 'date': 'Sun Aug 09 15:00:00 +0000 2026', 'chapter': 1190}
```

Values match what the API returns for the same call, and the refreshed `schedule.json` is included in this PR. The error path was also exercised (a call with a missing `secret`) and correctly raises `RuntimeError: Invalid Parameter: There are issues connecting to Manga+. ...`.

## Note

The workflow also logs a warning that `actions/checkout@v4` and `actions/setup-python@v4` target the deprecated Node 20. That is not what caused this failure and is not addressed here.
